### PR TITLE
50 parallelize audio processing

### DIFF
--- a/docs/reference/CandidateTracks.qmd
+++ b/docs/reference/CandidateTracks.qmd
@@ -1,38 +1,53 @@
 # CandidateTracks { #fasttrackpy.CandidateTracks }
 
-`CandidateTracks(self, sound, min_max_formant=4000, max_max_formant=7000, nstep=20, n_formants=4, window_length=0.025, time_step=0.002, pre_emphasis_from=50, smoother=Smoother(), loss_fun=Loss(), agg_fun=Agg())`
+`CandidateTracks(self, sound=None, samples=None, sampling_frequency=None, xmin=0.0, min_max_formant=4000, max_max_formant=7000, nstep=20, n_formants=4, window_length=0.025, time_step=0.002, pre_emphasis_from=50, smoother=Smoother(), loss_fun=Loss(), agg_fun=Agg())`
 
 A class for candidate tracks for a single formant
 
+You can provide *either*
+
+- A parselmouth `Sound` object to the `sound` argument
+
+xor
+
+- An array of audio samples to the `samples` argument
+- The sampling frequency to the `sampling_frequency` argument
+- Any optional time offset to the `xmin` argument.
+
+If a `Sound` object is passed to `sound`, any values passed to `samples`,
+`sampling_frequency` and `xmin` are ignored.
+
 ## Parameters
 
-| Name                | Type     | Description                                                              | Default      |
-|---------------------|----------|--------------------------------------------------------------------------|--------------|
-| `sound`             | pm.Sound | A `parselmouth.Sound` object.                                            | _required_   |
-| `min_max_formant`   | float    | The lowest max-formant value to try. Defaults to 4000.                   | `4000`       |
-| `max_max_formant`   | float    | The highest max formant to try. Defaults to 7000.                        | `7000`       |
-| `nstep`             | int      | The number of steps from the min to the max max formant. Defaults to 20. | `20`         |
-| `n_formants`        | int      | The number of formants to track. Defaults to 4.                          | `4`          |
-| `window_length`     | float    | Window length of the formant analysis. Defaults to 0.025.                | `0.025`      |
-| `time_step`         | float    | Time step of the formant analyusis window. Defaults to 0.002.            | `0.002`      |
-| `pre_emphasis_from` | float    | Pre-emphasis threshold. Defaults to 50.                                  | `50`         |
-| `smoother`          | Smoother | The smoother method to use. Defaults to `Smoother()`.                    | `Smoother()` |
-| `loss_fun`          | Loss     | The loss function to use. Defaults to Loss().                            | `Loss()`     |
-| `agg_fun`           | Agg      | The loss aggregation function to use. Defaults to Agg().                 | `Agg()`      |
+| Name                 | Type       | Description                                                              | Default      |
+|----------------------|------------|--------------------------------------------------------------------------|--------------|
+| `sound`              | pm.Sound   | A `parselmouth.Sound` object.                                            | `None`       |
+| `samples`            | np.ndarray | A numpy array of audio samples.                                          | `None`       |
+| `sampling_frequency` | float      | The audio sampling frequency.                                            | `None`       |
+| `xmin`               | float      | The time offset for the audio. Defaults to 0.0.                          | `0.0`        |
+| `min_max_formant`    | float      | The lowest max-formant value to try. Defaults to 4000.                   | `4000`       |
+| `max_max_formant`    | float      | The highest max formant to try. Defaults to 7000.                        | `7000`       |
+| `nstep`              | int        | The number of steps from the min to the max max formant. Defaults to 20. | `20`         |
+| `n_formants`         | int        | The number of formants to track. Defaults to 4.                          | `4`          |
+| `window_length`      | float      | Window length of the formant analysis. Defaults to 0.025.                | `0.025`      |
+| `time_step`          | float      | Time step of the formant analyusis window. Defaults to 0.002.            | `0.002`      |
+| `pre_emphasis_from`  | float      | Pre-emphasis threshold. Defaults to 50.                                  | `50`         |
+| `smoother`           | Smoother   | The smoother method to use. Defaults to `Smoother()`.                    | `Smoother()` |
+| `loss_fun`           | Loss       | The loss function to use. Defaults to Loss().                            | `Loss()`     |
+| `agg_fun`            | Agg        | The loss aggregation function to use. Defaults to Agg().                 | `Agg()`      |
 
 ## Attributes
 
-| Name           | Type                              | Description                                                                   |
-|----------------|-----------------------------------|-------------------------------------------------------------------------------|
-| candidates     | list\[OneTrack, ...\]             | A list of `OneTrack` tracks.                                                  |
-| min_n_measured | int                               | The smallest number of successfully measured formants across all `candidates` |
-| smooth_errors  | np.array                          | The error terms for each treack in `candidates`                               |
-| winner_idx     | int                               | The candidate track with the smallest error term                              |
-| winner         | OneTrack                          | The winning `OneTrack` track.                                                 |
-| file_name      | str                               | The filename of the audio file, if set.                                       |
-| interval       | aligned_textgrid.SequenceInterval | The textgrid interval of the sound, if set.                                   |
-| id             | str                               | The interval id of the sound, if set.                                         |
-| group          | str                               | The tier group name of the sound, if set.                                     |
+| Name          | Type                              | Description                                      |
+|---------------|-----------------------------------|--------------------------------------------------|
+| candidates    | list\[OneTrack, ...\]             | A list of `OneTrack` tracks.                     |
+| smooth_errors | np.array                          | The error terms for each treack in `candidates`  |
+| winner_idx    | int                               | The candidate track with the smallest error term |
+| winner        | OneTrack                          | The winning `OneTrack` track.                    |
+| file_name     | str                               | The filename of the audio file, if set.          |
+| interval      | aligned_textgrid.SequenceInterval | The textgrid interval of the sound, if set.      |
+| id            | str                               | The interval id of the sound, if set.            |
+| group         | str                               | The tier group name of the sound, if set.        |
 
 ## Methods
 

--- a/docs/reference/OneTrack.qmd
+++ b/docs/reference/OneTrack.qmd
@@ -1,38 +1,53 @@
 # OneTrack { #fasttrackpy.OneTrack }
 
-`OneTrack(self, maximum_formant, sound, n_formants=4, window_length=0.025, time_step=0.002, pre_emphasis_from=50, smoother=Smoother(), loss_fun=Loss(), agg_fun=Agg())`
+`OneTrack(self, maximum_formant, sound=None, samples=None, sampling_frequency=None, xmin=0.0, n_formants=4, window_length=0.025, time_step=0.002, pre_emphasis_from=50, smoother=Smoother(), loss_fun=Loss(), agg_fun=Agg())`
 
 A single formant track.
 
+You can provide *either*
+
+- A parselmouth `Sound` object to the `sound` argument
+
+xor
+
+- An array of audio samples to the `samples` argument
+- The sampling frequency to the `sampling_frequency` argument
+- Any optional time offset to the `xmin` argument.
+
+If a `Sound` object is passed to `sound`, any values passed to `samples`,
+`sampling_frequency` and `xmin` are ignored.
+
 ## Parameters
 
-| Name                | Type     | Description                                                   | Default      |
-|---------------------|----------|---------------------------------------------------------------|--------------|
-| `sound`             | pm.Sound | A `parselmouth.Sound` object.                                 | _required_   |
-| `maximum_formant`   | float    | max formant                                                   | _required_   |
-| `n_formants`        | int      | The number of formants to track. Defaults to 4.               | `4`          |
-| `window_length`     | float    | Window length of the formant analysis. Defaults to 0.025.     | `0.025`      |
-| `time_step`         | float    | Time step of the formant analyusis window. Defaults to 0.002. | `0.002`      |
-| `pre_emphasis_from` | float    | Pre-emphasis threshold. Defaults to 50.                       | `50`         |
-| `smoother`          | Smoother | The smoother method to use. Defaults to `Smoother()`.         | `Smoother()` |
-| `loss_fun`          | Loss     | The loss function to use. Defaults to Loss().                 | `Loss()`     |
-| `agg_fun`           | Agg      | The loss aggregation function to use. Defaults to Agg().      | `Agg()`      |
+| Name                 | Type       | Description                                                   | Default      |
+|----------------------|------------|---------------------------------------------------------------|--------------|
+| `sound`              | pm.Sound   | A `parselmouth.Sound` object.                                 | `None`       |
+| `samples`            | np.ndarray | A numpy array of audio samples.                               | `None`       |
+| `sampling_frequency` | float      | The audio sampling frequency.                                 | `None`       |
+| `xmin`               | float      | The time offset for the audio. Defaults to 0.0.               | `0.0`        |
+| `maximum_formant`    | float      | max formant                                                   | _required_   |
+| `n_formants`         | int        | The number of formants to track. Defaults to 4.               | `4`          |
+| `window_length`      | float      | Window length of the formant analysis. Defaults to 0.025.     | `0.025`      |
+| `time_step`          | float      | Time step of the formant analyusis window. Defaults to 0.002. | `0.002`      |
+| `pre_emphasis_from`  | float      | Pre-emphasis threshold. Defaults to 50.                       | `50`         |
+| `smoother`           | Smoother   | The smoother method to use. Defaults to `Smoother()`.         | `Smoother()` |
+| `loss_fun`           | Loss       | The loss function to use. Defaults to Loss().                 | `Loss()`     |
+| `agg_fun`            | Agg        | The loss aggregation function to use. Defaults to Agg().      | `Agg()`      |
 
 ## Attributes
 
-| Name                | Type                              | Description                                                                                  |
-|---------------------|-----------------------------------|----------------------------------------------------------------------------------------------|
-| maximum_formant     | float                             | The max formant                                                                              |
-| time_domain         | np.array                          | The time domain of the formant estimates                                                     |
-| formants            | np.ndarray                        | A (formants, time) array of values. The formants as initially estimated by praat-parselmouth |
-| n_measured_formants | int                               | The total number of formants for which formant tracks were estimatable                       |
-| smoothed_formants   | np.ndarray                        | The smoothed formant values, using the method passed to `smoother`.                          |
-| parameters          | np.ndarray                        | The smoothing parameters.                                                                    |
-| smooth_error        | float                             | The error term between formants and smoothed formants.                                       |
-| file_name           | str                               | The filename of the audio file, if set.                                                      |
-| interval            | aligned_textgrid.SequenceInterval | The textgrid interval of the sound, if set.                                                  |
-| id                  | str                               | The interval id of the sound, if set.                                                        |
-| group               | str                               | The tier group name of the sound, if set.                                                    |
+| Name              | Type                              | Description                                                                                  |
+|-------------------|-----------------------------------|----------------------------------------------------------------------------------------------|
+| maximum_formant   | float                             | The max formant                                                                              |
+| time_domain       | np.array                          | The time domain of the formant estimates                                                     |
+| formants          | np.ndarray                        | A (formants, time) array of values. The formants as initially estimated by praat-parselmouth |
+| smoothed_formants | np.ndarray                        | The smoothed formant values, using the method passed to `smoother`.                          |
+| parameters        | np.ndarray                        | The smoothing parameters.                                                                    |
+| smooth_error      | float                             | The error term between formants and smoothed formants.                                       |
+| file_name         | str                               | The filename of the audio file, if set.                                                      |
+| interval          | aligned_textgrid.SequenceInterval | The textgrid interval of the sound, if set.                                                  |
+| id                | str                               | The interval id of the sound, if set.                                                        |
+| group             | str                               | The tier group name of the sound, if set.                                                    |
 
 ## Methods
 

--- a/src/fasttrackpy/patterns/audio_textgrid.py
+++ b/src/fasttrackpy/patterns/audio_textgrid.py
@@ -6,7 +6,6 @@ from fasttrackpy.patterns.just_audio import create_audio_checker
 import re
 
 from pathlib import Path
-import multiprocessing
 from tqdm import tqdm
 from joblib import Parallel, cpu_count, delayed
 import warnings
@@ -152,6 +151,7 @@ def process_audio_textgrid(
         {
             "samples": x.values,
             "sampling_frequency": x.sampling_frequency,
+            "xmin": x.xmin,
             #"interval": interval,
             "min_max_formant": min_max_formant,
             "max_max_formant": max_max_formant,

--- a/src/fasttrackpy/patterns/audio_textgrid.py
+++ b/src/fasttrackpy/patterns/audio_textgrid.py
@@ -8,7 +8,7 @@ import re
 from pathlib import Path
 import multiprocessing
 from tqdm import tqdm
-from joblib import Parallel, delayed, wrap_non_picklable_objects
+from joblib import Parallel, cpu_count, delayed
 import warnings
 
 try:
@@ -66,7 +66,6 @@ def get_target_intervals(
     return intervals
 
 @delayed
-@wrap_non_picklable_objects
 def get_candidates(args_dict):
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
@@ -151,7 +150,8 @@ def process_audio_textgrid(
 
     arg_list = [
         {
-            "sound": x,
+            "samples": x.values,
+            "sampling_frequency": x.sampling_frequency,
             #"interval": interval,
             "min_max_formant": min_max_formant,
             "max_max_formant": max_max_formant,
@@ -166,8 +166,8 @@ def process_audio_textgrid(
         } for x, interval in zip(sound_parts, target_intervals)
     ]
     
-    n_jobs = multiprocessing.cpu_count()
-    candidate_list = Parallel(n_jobs=n_jobs, prefer="threads")(
+    n_jobs = cpu_count()
+    candidate_list = Parallel(n_jobs=n_jobs)(
         get_candidates(args_dict=arg) for arg in tqdm(arg_list)
         )
     for cand, interval in zip(candidate_list, target_intervals):

--- a/src/fasttrackpy/patterns/corpus.py
+++ b/src/fasttrackpy/patterns/corpus.py
@@ -7,7 +7,6 @@ from fasttrackpy.patterns.audio_textgrid import get_interval_classes
 import re
 from collections import namedtuple
 from pathlib import Path
-import multiprocessing
 from tqdm import tqdm
 from functools import reduce
 from operator import add
@@ -188,6 +187,7 @@ def process_corpus(
             {
                 "samples": x.values,
                 "sampling_frequency": x.sampling_frequency,
+                "xmin": x.xmin,
                 #"interval": interval,
                 "min_max_formant": min_max_formant,
                 "max_max_formant": max_max_formant,

--- a/src/fasttrackpy/patterns/just_audio.py
+++ b/src/fasttrackpy/patterns/just_audio.py
@@ -8,7 +8,6 @@ from fasttrackpy import CandidateTracks,\
                         Loss,\
                         Agg
 
-import multiprocessing
 from tqdm import tqdm
 from joblib import Parallel, cpu_count, delayed
 
@@ -121,6 +120,7 @@ def process_audio_file(
     candidates = CandidateTracks(
         samples=sound_to_process.values,
         sampling_frequency=sound_to_process.sampling_frequency,
+        xmin = sound_to_process.xmin,
         min_max_formant=min_max_formant,
         max_max_formant=max_max_formant,
         nstep=nstep,

--- a/src/fasttrackpy/processors/outputs.py
+++ b/src/fasttrackpy/processors/outputs.py
@@ -383,17 +383,6 @@ def candidate_spectrograms(
         ax.label_outer()
 
 
-class ftpSound:
-    def __init__(self, sound):
-        self.values = np.array(sound.values)
-        self.sampling_frequency = sound.sampling_frequency
-
-    def to_pmSound(self):
-        output = pm.Sound(self.values,
-                        sampling_frequency=self.sampling_frequency)
-        return (output)
-
-
 def pickle_candidates(
     candidates,
     file: Path|str
@@ -414,14 +403,7 @@ def pickle_candidates(
     if type(file) is str:
         file = Path(file)
 
-    tmp_sound = ftpSound(candidates.sound)
-
     tmp_candidates = copy.deepcopy (candidates)
-
-    for candidate in tmp_candidates.candidates:
-        candidate.sound = tmp_sound
-
-    tmp_candidates.sound = tmp_sound
 
     with file.open('wb') as f:
         pickle.dump(tmp_candidates, f)
@@ -449,11 +431,4 @@ def unpickle_candidates(
     with file.open('rb') as f:
         candidates = pickle.load(f)
 
-    tmp_sound = candidates.sound.to_pmSound()
-
-    for candidate in candidates.candidates:
-        candidate.sound = tmp_sound
-
-    candidates.sound = tmp_sound
-
-    return (candidates)
+    return candidates

--- a/src/fasttrackpy/tracks.py
+++ b/src/fasttrackpy/tracks.py
@@ -12,11 +12,18 @@ import matplotlib.pyplot as mp
 from aligned_textgrid import SequenceInterval
 from aligned_textgrid.sequences.tiers import TierGroup
 
+from joblib import Parallel, cpu_count, delayed
+
 import polars as pl
 
 from typing import Union, Literal
 import warnings
 import logging
+
+try:
+    CPUS = cpu_count()
+except NotImplementedError:
+    CPUS = 2
 
 
 class Track:

--- a/src/fasttrackpy/tracks.py
+++ b/src/fasttrackpy/tracks.py
@@ -41,7 +41,11 @@ class Track:
             loss_fun: Loss = Loss(),
             agg_fun: Agg = Agg()
     ):
-        self.sound = sound
+        #self.sound = sound
+        self.samples = sound.values
+        self.sampling_frequency = sound.sampling_frequency
+        self.xmin = sound.xmin
+        self.xmax = sound.xmax
         self.n_formants = n_formants
         self.window_length = window_length
         self.time_step = time_step
@@ -49,6 +53,16 @@ class Track:
         self.smoother = smoother
         self.loss_fun = loss_fun
         self.agg_fun = agg_fun
+        
+    @property
+    def sound(self):
+        sound_obj = pm.Sound(
+            self.samples, 
+            sampling_frequency = self.sampling_frequency,
+            start_time = self.xmin
+        )
+        return sound_obj        
+
 
 class OneTrack(Track):
     """A single formant track.

--- a/src/fasttrackpy/tracks.py
+++ b/src/fasttrackpy/tracks.py
@@ -31,7 +31,8 @@ class Track:
             self,
             sound: pm.Sound = None,
             samples: np.array = None,
-            sampling_frequency: float = None,            
+            sampling_frequency: float = None,
+            xmin: float = None,            
             n_formants: int = 4,
             window_length: float = 0.05,
             time_step: float = 0.002,
@@ -45,11 +46,10 @@ class Track:
             self.samples = sound.values
             self.sampling_frequency = sound.sampling_frequency
             self.xmin = sound.xmin
-            self.xmax = sound.xmax
         else:
             self.samples = samples
             self.sampling_frequency = sampling_frequency
-            self.xmin = 0            
+            self.xmin = xmin           
         self.n_formants = n_formants
         self.window_length = window_length
         self.time_step = time_step
@@ -110,6 +110,7 @@ class OneTrack(Track):
             sound: pm.Sound = None,
             samples: np.array = None,
             sampling_frequency: float = None,
+            xmin: float = None,
             n_formants: int = 4,
             window_length: float = 0.025,
             time_step: float = 0.002,
@@ -122,6 +123,7 @@ class OneTrack(Track):
             sound=sound,
             samples = samples,
             sampling_frequency=sampling_frequency,
+            xmin = xmin,
             n_formants=n_formants,
             window_length=window_length,
             time_step=time_step,
@@ -349,6 +351,7 @@ class CandidateTracks(Track):
         sound: pm.Sound = None,
         samples: np.array = None,
         sampling_frequency: float = None,
+        xmin: float = None,
         min_max_formant: float = 4000,
         max_max_formant: float = 7000,
         nstep = 20,
@@ -364,6 +367,7 @@ class CandidateTracks(Track):
             sound=sound,
             samples = samples,
             sampling_frequency = sampling_frequency,
+            xmin = xmin,
             n_formants=n_formants,
             window_length=window_length,
             time_step=time_step,
@@ -391,16 +395,17 @@ class CandidateTracks(Track):
 
         to_process = [
             {
-                "samples": (self.samples),
-                "sampling_frequency": (self.sampling_frequency),
-                "maximum_formant": (max_formant),
-                "n_formants": (self.n_formants),
-                "window_length": (self.window_length),
-                "time_step": (self.time_step),
-                "pre_emphasis_from": (self.pre_emphasis_from),
-                "smoother": (self.smoother),
-                "loss_fun": (self.loss_fun),
-                "agg_fun": (self.agg_fun)                
+                "samples": self.samples,
+                "sampling_frequency": self.sampling_frequency,
+                "xmin": self.xmin,
+                "maximum_formant": max_formant,
+                "n_formants": self.n_formants,
+                "window_length": self.window_length,
+                "time_step": self.time_step,
+                "pre_emphasis_from": self.pre_emphasis_from,
+                "smoother": self.smoother,
+                "loss_fun": self.loss_fun,
+                "agg_fun": self.agg_fun                
 
             }
             for max_formant in self.max_formants

--- a/src/fasttrackpy/tracks.py
+++ b/src/fasttrackpy/tracks.py
@@ -12,19 +12,12 @@ import matplotlib.pyplot as mp
 from aligned_textgrid import SequenceInterval
 from aligned_textgrid.sequences.tiers import TierGroup
 
-from joblib import Parallel, cpu_count, delayed
-
 import polars as pl
 
 from typing import Union, Literal
 import warnings
 import logging
-from copy import deepcopy
 
-try:
-    CPUS = cpu_count()
-except NotImplementedError:
-    CPUS = 2
 
 def _make_candidate(args_dict):
     track = OneTrack(**args_dict)
@@ -416,11 +409,6 @@ class CandidateTracks(Track):
         self.candidates = [
             _make_candidate(x) for x in to_process
         ]
-
-        # self.candidates = Parallel(n_jobs=CPUS)(
-        #     delayed(_make_candidate)(x)
-        #     for x in to_process
-        # )
 
         self.smooth_errors = np.array(
             [x.smooth_error for x in self.candidates]

--- a/src/fasttrackpy/tracks.py
+++ b/src/fasttrackpy/tracks.py
@@ -398,25 +398,29 @@ class CandidateTracks(Track):
 
         to_process = [
             {
-                "samples": deepcopy(self.samples),
-                "sampling_frequency": deepcopy(self.sampling_frequency),
-                "maximum_formant": deepcopy(max_formant),
-                "n_formants": deepcopy(self.n_formants),
-                "window_length": deepcopy(self.window_length),
-                "time_step": deepcopy(self.time_step),
-                "pre_emphasis_from": deepcopy(self.pre_emphasis_from),
-                "smoother": deepcopy(self.smoother),
-                "loss_fun": deepcopy(self.loss_fun),
-                "agg_fun": deepcopy(self.agg_fun)                
+                "samples": (self.samples),
+                "sampling_frequency": (self.sampling_frequency),
+                "maximum_formant": (max_formant),
+                "n_formants": (self.n_formants),
+                "window_length": (self.window_length),
+                "time_step": (self.time_step),
+                "pre_emphasis_from": (self.pre_emphasis_from),
+                "smoother": (self.smoother),
+                "loss_fun": (self.loss_fun),
+                "agg_fun": (self.agg_fun)                
 
             }
             for max_formant in self.max_formants
         ]
 
-        self.candidates = Parallel(n_jobs=CPUS)(
-            delayed(_make_candidate)(x)
-            for x in to_process
-        )
+        self.candidates = [
+            _make_candidate(x) for x in to_process
+        ]
+
+        # self.candidates = Parallel(n_jobs=CPUS)(
+        #     delayed(_make_candidate)(x)
+        #     for x in to_process
+        # )
 
         self.smooth_errors = np.array(
             [x.smooth_error for x in self.candidates]

--- a/src/fasttrackpy/tracks.py
+++ b/src/fasttrackpy/tracks.py
@@ -32,7 +32,7 @@ class Track:
             sound: pm.Sound = None,
             samples: np.array = None,
             sampling_frequency: float = None,
-            xmin: float = None,            
+            xmin: float = 0.0,            
             n_formants: int = 4,
             window_length: float = 0.05,
             time_step: float = 0.002,
@@ -71,8 +71,24 @@ class Track:
 class OneTrack(Track):
     """A single formant track.
 
+    You can provide *either*
+
+    - A parselmouth `Sound` object to the `sound` argument
+
+    xor
+
+    - An array of audio samples to the `samples` argument
+    - The sampling frequency to the `sampling_frequency` argument
+    - Any optional time offset to the `xmin` argument.
+
+    If a `Sound` object is passed to `sound`, any values passed to `samples`,
+    `sampling_frequency` and `xmin` are ignored.
+
     Args:
-        sound (pm.Sound): A `parselmouth.Sound` object.
+        sound (pm.Sound, optional): A `parselmouth.Sound` object.
+        samples (np.ndarray, optional): A numpy array of audio samples.
+        sampling_frequency (float, optional): The audio sampling frequency.
+        xmin (float, optional): The time offset for the audio. Defaults to 0.0.
         maximum_formant (float): max formant
         n_formants (int, optional): The number of formants to track. Defaults to 4.
         window_length (float, optional): Window length of the formant analysis.
@@ -110,7 +126,7 @@ class OneTrack(Track):
             sound: pm.Sound = None,
             samples: np.array = None,
             sampling_frequency: float = None,
-            xmin: float = None,
+            xmin: float = 0.0,
             n_formants: int = 4,
             window_length: float = 0.025,
             time_step: float = 0.002,
@@ -311,8 +327,25 @@ class OneTrack(Track):
 class CandidateTracks(Track):
     """A class for candidate tracks for a single formant
 
+    You can provide *either*
+
+    - A parselmouth `Sound` object to the `sound` argument
+
+    xor
+
+    - An array of audio samples to the `samples` argument
+    - The sampling frequency to the `sampling_frequency` argument
+    - Any optional time offset to the `xmin` argument.
+
+    If a `Sound` object is passed to `sound`, any values passed to `samples`,
+    `sampling_frequency` and `xmin` are ignored.
+
+
     Args:
-        sound (pm.Sound): A `parselmouth.Sound` object.
+        sound (pm.Sound, optional): A `parselmouth.Sound` object.
+        samples (np.ndarray, optional): A numpy array of audio samples.
+        sampling_frequency (float, optional): The audio sampling frequency.
+        xmin (float, optional): The time offset for the audio. Defaults to 0.0.
         min_max_formant (float, optional): The lowest max-formant value to try.
             Defaults to 4000.
         max_max_formant (float, optional): The highest max formant to try.
@@ -335,8 +368,6 @@ class CandidateTracks(Track):
 
     Attributes:
         candidates (list[OneTrack,...]): A list of `OneTrack` tracks.
-        min_n_measured (int): The smallest number of successfully measured
-            formants across all `candidates`
         smooth_errors (np.array): The error terms for each treack in `candidates`
         winner_idx (int): The candidate track with the smallest error term
         winner (OneTrack): The winning `OneTrack` track.
@@ -351,7 +382,7 @@ class CandidateTracks(Track):
         sound: pm.Sound = None,
         samples: np.array = None,
         sampling_frequency: float = None,
-        xmin: float = None,
+        xmin: float = 0.0,
         min_max_formant: float = 4000,
         max_max_formant: float = 7000,
         nstep = 20,


### PR DESCRIPTION
Major components of this update:

- The parselmouth.Sound object is no longer directly stored within track objects. Rather, the audio samples, sampling frequencies, and start time offsets are stored, and the the `.sound` object is created on the fly just for formant tracking. This allows the audio data to be directly pickle-able, which makes joblib parallelization possible. It also simplifies some of the pickling and un-pickling code.
- The formant tracking of each individual segment is now parallelized, leading to *considerable* speedup when processing multiple segments.