### PR TITLE
DCT parameters in log space

### DIFF
--- a/src/fasttrackpy/cli.py
+++ b/src/fasttrackpy/cli.py
@@ -145,7 +145,7 @@ output_options = cloup.option_group(
     ),
     cloup.option(
         "--data-output", 
-        type=click.Choice(["formants", "param"]), 
+        type=click.Choice(["formants", "param", "log_param"]), 
         default="formants",
         help = "Whether to save the formant data, "\
                "or smoothing parameter data."\

--- a/src/fasttrackpy/processors/outputs.py
+++ b/src/fasttrackpy/processors/outputs.py
@@ -100,6 +100,29 @@ def param_to_dataframe(self):
 
     return param_df
 
+def log_param_to_dataframe(self):
+    """Return data as a data frame
+
+    Returns:
+        (pl.DataFrame): A data frame
+    """
+
+    schema = [
+        f"F{x}" for x in
+        np.arange(self.log_parameters.shape[0])+1
+    ]
+    param_df = pl.DataFrame(
+        data = self.log_parameters,schema=schema
+    )
+
+    param_df = param_df.with_columns(
+        error = pl.lit(self.smooth_error)
+    ).with_row_count(name = "param")
+
+    param_df = add_metadata(self, param_df)
+
+    return param_df
+
 def get_big_df(self, output):
         all_df = [x.to_df(output = output) for x in self.candidates]
         all_df = [

--- a/src/fasttrackpy/tracks.py
+++ b/src/fasttrackpy/tracks.py
@@ -159,6 +159,7 @@ class OneTrack(Track):
         self._group = None
         self._formant_df = None
         self._param_df = None
+        self._log_param_df = None
         self._interval = None
 
     def __repr__(self):
@@ -448,6 +449,7 @@ class CandidateTracks(Track):
         self._group = None
         self._formant_df = None
         self._param_df = None
+        self._log_param_df = None
         self._interval = None
 
         to_process = [

--- a/tests/test_outputs.py
+++ b/tests/test_outputs.py
@@ -19,6 +19,31 @@ from PIL import Image
 SOUND_PATH = Path("tests", "test_data", "ay.wav")
 SOUND = pm.Sound(str(SOUND_PATH))
 
+class TestDataFrames:
+    candidates = CandidateTracks(sound = SOUND)
+    def test_formant_df(self):
+       
+        formant_df = self.candidates.to_df(output="formants")
+        big_formant_df = self.candidates.to_df(which='all', output="formants")
+
+        assert isinstance(formant_df, pl.DataFrame)
+        assert isinstance(big_formant_df, pl.DataFrame)
+
+    def test_param_df(self):
+        param_df = self.candidates.to_df(output="param")
+        big_param_df = self.candidates.to_df(which='all', output="formants")
+
+        assert isinstance(param_df, pl.DataFrame)
+        assert isinstance(big_param_df, pl.DataFrame)
+
+    def test_log_param_df(self):
+        log_param_df = self.candidates.to_df(output="log_param")
+        big_log_param_df = self.candidates.to_df(which='all', output='log_param')
+
+        assert isinstance(log_param_df, pl.DataFrame)                
+        assert isinstance(big_log_param_df, pl.DataFrame)
+
+
 class TestWrite:
 
     def test_formant_write(self):


### PR DESCRIPTION
This doesn't change the behavior of how fasttrackpy selects max formants. It adds an additional option to access DCT parameters estimated in log-space.