### PR TITLE
Pickle Updates

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,10 +30,11 @@ python-magic-bin = {version = "^0.4.14", markers = "sys_platform == 'win32'"}
 click = "^8.1.7"
 cloup = "^3.0.3"
 matplotlib = "^3.8.2"
-aligned-textgrid = "^0.6.2"
+aligned-textgrid = "^0.6.7"
 tqdm = "^4.66.1"
 joblib = "^1.3.2"
 pyyaml = "^6.0.1"
+cloudpickle = "^3.0.0"
 
 [tool.poetry.group.dev.dependencies]
 jupyter = "^1.0.0"

--- a/src/fasttrackpy/processors/outputs.py
+++ b/src/fasttrackpy/processors/outputs.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import matplotlib.pyplot as mp
 import copy
 import logging
+import sys
 
 ptolmap = {"F1" :"#4477AA",
            "F1_s": "#4477AA",
@@ -425,7 +426,7 @@ def pickle_candidates(
     """
     if type(file) is str:
         file = Path(file)
-
+    sys.setrecursionlimit(3000)
     #tmp_candidates = copy.deepcopy (candidates)
 
     with file.open('wb') as f:
@@ -450,7 +451,7 @@ def unpickle_candidates(
     """
     if type(file) is str:
         file = Path(file)    
-
+    sys.setrecursionlimit(3000)
     with file.open('rb') as f:
         candidates = cloudpickle.load(f)
 

--- a/src/fasttrackpy/processors/outputs.py
+++ b/src/fasttrackpy/processors/outputs.py
@@ -1,5 +1,5 @@
 import numpy as np
-import pickle
+import cloudpickle
 import parselmouth as pm
 import polars as pl
 from aligned_textgrid import SequenceInterval
@@ -429,7 +429,7 @@ def pickle_candidates(
     tmp_candidates = copy.deepcopy (candidates)
 
     with file.open('wb') as f:
-        pickle.dump(tmp_candidates, f)
+        cloudpickle.dump(tmp_candidates, f)
 
 
 def unpickle_candidates(
@@ -452,6 +452,6 @@ def unpickle_candidates(
         file = Path(file)    
 
     with file.open('rb') as f:
-        candidates = pickle.load(f)
+        candidates = cloudpickle.load(f)
 
     return candidates

--- a/src/fasttrackpy/processors/outputs.py
+++ b/src/fasttrackpy/processors/outputs.py
@@ -426,10 +426,10 @@ def pickle_candidates(
     if type(file) is str:
         file = Path(file)
 
-    tmp_candidates = copy.deepcopy (candidates)
+    #tmp_candidates = copy.deepcopy (candidates)
 
     with file.open('wb') as f:
-        cloudpickle.dump(tmp_candidates, f)
+        cloudpickle.dump(candidates, f)
 
 
 def unpickle_candidates(

--- a/tests/test_outputs.py
+++ b/tests/test_outputs.py
@@ -167,5 +167,5 @@ class TestPickle:
         pickle_candidates(cands2[0], file = pickle_file)
         assert pickle_file.exists()
 
-        #re_read = unpickle_candidates(file = pickle_file)
-        #assert len(re_read.candidates) == len(self.cands2[0].candidates)
+        re_read = unpickle_candidates(file = pickle_file)
+        assert len(re_read.candidates) == len(cands2[0].candidates)

--- a/tests/test_outputs.py
+++ b/tests/test_outputs.py
@@ -9,6 +9,7 @@ from fasttrackpy.processors.outputs import write_data, \
     pickle_candidates,\
     unpickle_candidates
 from fasttrackpy.patterns.just_audio import process_audio_file
+from fasttrackpy import process_audio_textgrid
 import parselmouth as pm
 import polars as pl
 import numpy as np
@@ -142,6 +143,7 @@ class TestPlots:
 
 class TestPickle:
     cands = CandidateTracks(SOUND)
+    
 
     def test_pickle_unpickle(self, tmp_path):
         pickle_file = tmp_path / "cand.pkl"
@@ -155,3 +157,15 @@ class TestPickle:
             self.cands.winner.maximum_formant
             )
         assert len(re_read.candidates) == len(self.cands.candidates)
+
+    def test_big_pickle_unpickle(self, tmp_path):
+        cands2 = process_audio_textgrid(
+            audio_path=Path("tests", "test_data", "corpus", "josef-fruehwald_speaker.wav"),
+            textgrid_path=Path("tests", "test_data", "corpus", "josef-fruehwald_speaker.TextGrid"),
+        )
+        pickle_file = tmp_path / "cand2.pkl"
+        pickle_candidates(cands2[0], file = pickle_file)
+        assert pickle_file.exists()
+
+        #re_read = unpickle_candidates(file = pickle_file)
+        #assert len(re_read.candidates) == len(self.cands2[0].candidates)


### PR DESCRIPTION
Some updates in aligned-textgrid broke default pickling, but replacing `pickle.dump` with `cloudpickle.dump` resolves the problem.